### PR TITLE
Crash issue fixed when executing from console

### DIFF
--- a/src/muqsit/wilderness/Wilderness.php
+++ b/src/muqsit/wilderness/Wilderness.php
@@ -14,6 +14,10 @@ use pocketmine\plugin\PluginBase;
 class Wilderness extends PluginBase{
 
 	public function onCommand(CommandSender $sender, Command $cmd, string $label, array $args) : bool{
+		if(!$sender instanceof Player){
+	        $sender->sendMessage("Please use this command in game.");
+	        return true;
+	    	}
 		$level = $sender->getLevel();
 		$x = mt_rand(-10000, 10000);
 		$z = mt_rand(-10000, 10000);


### PR DESCRIPTION
So this PR is just a small fix for when you execute /wild command from console, it'll crash the server. I know some people would be foolish to use it from console, but hey! it's a fix so you don't have any server crashes via console or anything as such.
This plugin is decently nice, I like how the code system works. I'll test more soon, and maybe do another PR if found more bugs. Anyways, you might want to merge this in any case, foolish or not. Just in case if people abuse this issue, and would be great to know that this would be fixed.
This hasn't been fully tested, but I'm sure this is the fix for the issue stated above.
Please test before merging. Thank you!